### PR TITLE
fix remove_line_break_before_curly_opening

### DIFF
--- a/R/rules-line_break.R
+++ b/R/rules-line_break.R
@@ -1,6 +1,6 @@
 # A { should never go on its own line
 remove_line_break_before_curly_opening <- function(pd) {
-  rm_break <- pd$token_after == "'{'"
+  rm_break <- (pd$token_after == "'{'") & (pd$token != "COMMENT")
   pd$lag_newlines[lag(rm_break)] <- 0L
   pd
 }

--- a/tests/testthat/indention_operators/while_for_if_without_curly-in_tree
+++ b/tests/testthat/indention_operators/while_for_if_without_curly-in_tree
@@ -37,7 +37,7 @@ ROOT (token: short_text [lag_newlines/spaces] {id})
  ¦       ¦   °--SYMBOL: i [0/0] {44}                  
  ¦       °--')': ) [0/0] {45}                         
  °--expr:  [2/0] {75}                                 
-     ¦--IF: if [0/0] {57}                             
+     ¦--IF: if [0/1] {57}                             
      ¦--'(': ( [0/0] {58}                             
      ¦--expr:  [0/0] {61}                             
      ¦   °--SYMBOL: x [0/0] {59}                      

--- a/tests/testthat/line_breaks_and_other/edge_comment_and_curly-in.R
+++ b/tests/testthat/line_breaks_and_other/edge_comment_and_curly-in.R
@@ -1,0 +1,4 @@
+a <- function(x) # this is a comment and the bracket below should not be moved one line up after the comment.
+{
+  x
+}

--- a/tests/testthat/line_breaks_and_other/edge_comment_and_curly-in_tree
+++ b/tests/testthat/line_breaks_and_other/edge_comment_and_curly-in_tree
@@ -1,0 +1,16 @@
+ROOT (token: short_text [lag_newlines/spaces] {id})
+ °--expr:  [0/0] {24}                              
+     ¦--expr:  [0/1] {3}                           
+     ¦   °--SYMBOL: a [0/0] {1}                    
+     ¦--LEFT_ASSIGN: <- [0/1] {2}                  
+     °--expr:  [0/0] {23}                          
+         ¦--FUNCTION: funct [0/0] {4}              
+         ¦--'(': ( [0/0] {5}                       
+         ¦--SYMBOL_FORMALS: x [0/0] {6}            
+         ¦--')': ) [0/1] {7}                       
+         ¦--COMMENT: # thi [0/0] {9}               
+         °--expr:  [1/0] {20}                      
+             ¦--'{': { [0/2] {11}                  
+             ¦--expr:  [1/0] {15}                  
+             ¦   °--SYMBOL: x [0/0] {13}           
+             °--'}': } [1/0] {18}                  

--- a/tests/testthat/line_breaks_and_other/edge_comment_and_curly-out.R
+++ b/tests/testthat/line_breaks_and_other/edge_comment_and_curly-out.R
@@ -1,0 +1,4 @@
+a <- function(x) # this is a comment and the bracket below should not be moved one line up after the comment.
+{
+  x
+}

--- a/tests/testthat/test-line_breaks_and_other.R
+++ b/tests/testthat/test-line_breaks_and_other.R
@@ -11,6 +11,11 @@ test_that("line breaks involing curly brackets", {
                   transformer = style_text), NA)
 })
 
+test_that("line breaks involing curly brackets", {
+  expect_warning(test_collection("line_breaks_and_other", "edge_comment_and_curly",
+                                 transformer = style_text), NA)
+})
+
 test_that("adding and removing line breaks", {
   expect_warning(test_collection("line_breaks_and_other", "if",
                   transformer = style_text), NA)


### PR DESCRIPTION
Don't remove line break if token before "'{'" is a comment. Closes #89