### PR TITLE
definitively fixing eol issue with comments

### DIFF
--- a/R/nested.R
+++ b/R/nested.R
@@ -101,20 +101,18 @@ add_terminal_token_before <- function(pd_flat) {
 #'
 #' @param spaces_after_prefix An integer vector with the number of spaces
 #'   after the prefix.
-#' @param text_length Integer vector giving the number of characters of
-#'   the text.
 #' @param force_one Whether spaces_after_prefix should be set to one in all
 #'   cases.
 #' @return An integer vector of length spaces_after_prefix, which is either
 #'   one (if `force_one = TRUE`) or `space_after_prefix` with all values
 #'   below one set to one.
-set_spaces <- function(spaces_after_prefix, text_length, force_one) {
+set_spaces <- function(spaces_after_prefix, force_one) {
   if (force_one) {
     n_of_spaces <- rep(1, length(spaces_after_prefix))
   } else {
     n_of_spaces <- pmax(spaces_after_prefix, 1L)
   }
-  ifelse(text_length > 0, n_of_spaces, 0)
+  n_of_spaces
 }
 
 #' Nest a flat parse table

--- a/R/rules-spacing.R
+++ b/R/rules-spacing.R
@@ -157,15 +157,16 @@ start_comments_with_space <- function(pd, force_one = FALSE) {
   comments$space_after_prefix <- nchar(comments$space_after_prefix)
   comments$space_after_prefix <- set_spaces(
     spaces_after_prefix = comments$space_after_prefix,
-    text_length = nchar(trimws(comments$text, "right")),
     force_one
   )
 
-  comments$text <- paste0(
-    comments$prefix,
-    map_chr(comments$space_after_prefix, rep_char, char = " "),
-    comments$text
-  )
+  comments$text <-
+    paste0(
+      comments$prefix,
+      map_chr(comments$space_after_prefix, rep_char, char = " "),
+      comments$text
+    ) %>%
+    trimws("right")
   comments$short <- substr(comments$text, 1, 5)
 
   comments[, setdiff(names(comments), c("space_after_prefix", "prefix"))] %>%

--- a/man/set_spaces.Rd
+++ b/man/set_spaces.Rd
@@ -4,14 +4,11 @@
 \alias{set_spaces}
 \title{Helper for setting spaces}
 \usage{
-set_spaces(spaces_after_prefix, text_length, force_one)
+set_spaces(spaces_after_prefix, force_one)
 }
 \arguments{
 \item{spaces_after_prefix}{An integer vector with the number of spaces
 after the prefix.}
-
-\item{text_length}{Integer vector giving the number of characters of
-the text.}
 
 \item{force_one}{Whether spaces_after_prefix should be set to one in all
 cases.}

--- a/tests/testthat/indention_multiple/overall-in.R
+++ b/tests/testthat/indention_multiple/overall-in.R
@@ -1,30 +1,31 @@
-#'this function does
+#' this function does
 #'
 #' @param x a parameter.
 #'    indented comments
-a<- function(x){
-  test_that("I want to test",{
-    out <- c(1,c(
-      22 +1
+a <- function(x) {
+  test_that("I want to test", {
+    out <- c(1, c(
+      22 + 1
     ))
     if (x > 10) {
       for (x in 22) { # FIXME in operator only to be surrounded by one space. What about %in%?
         prin(x)
       }
     }
-  }     )
-  #we like comments too
-  c(list(x + 2),
-    c(    c(
+  })
+  # we like comments too
+  c(
+    list(x + 2),
+    c(c(
       26 ^ 2, # FIXME ^ operator has to be surrounded by one space (or none?!), never multiple
       8,
       7
-    )   ) )
+  )))
 
   call(
     1, 2,
-    23+Inf - 99, call(
+    23 + Inf - 99, call(
       16
-    ))
+  ))
 }
 # comments everywhere

--- a/tests/testthat/parse_comments/eol_eof_spaces-in.R
+++ b/tests/testthat/parse_comments/eol_eof_spaces-in.R
@@ -1,0 +1,5 @@
+# comment      
+#' spaces      
+a            
+
+

--- a/tests/testthat/parse_comments/eol_eof_spaces-in_tree
+++ b/tests/testthat/parse_comments/eol_eof_spaces-in_tree
@@ -1,0 +1,5 @@
+ROOT (token: short_text [lag_newlines/spaces] {id})
+ ¦--COMMENT: # com [0/0] {1}                       
+ ¦--COMMENT: #' sp [1/0] {4}                       
+ °--expr:  [1/0] {9}                               
+     °--SYMBOL: a [0/0] {7}                        

--- a/tests/testthat/parse_comments/eol_eof_spaces-out.R
+++ b/tests/testthat/parse_comments/eol_eof_spaces-out.R
@@ -1,0 +1,3 @@
+# comment
+#' spaces
+a

--- a/tests/testthat/test-parse_comments.R
+++ b/tests/testthat/test-parse_comments.R
@@ -16,6 +16,10 @@ test_that("spacing within comments is done correctly", {
                                  transformers = get_transformers(
                                    flat = FALSE,
                                    start_comments_with_one_space = FALSE)), NA)
+
+  expect_warning(test_collection("parse_comments",
+                                 "eol_eof_spaces",
+                                 transformer = style_text), NA)
 })
 
 test_that("spacing before comments is done correctly", {


### PR DESCRIPTION
I think the problem can be solved by simply trimming white spaces *after* the space is inserted between `#` and text, otherwise we miss spaces at the end of comments.