### PR TITLE
add nonstrict version of set_space_before_comment

### DIFF
--- a/R/rules-spacing.R
+++ b/R/rules-spacing.R
@@ -183,8 +183,17 @@ set_space_before_comments <- function(pd_flat) {
   comment_before <- lead(comment_after, default = FALSE)
   pd_flat$spaces[comment_before & (pd_flat$newlines == 0L)] <- 1L
   pd_flat
-
 }
+
+add_space_before_comments <- function(pd_flat) {
+  comment_after <- (pd_flat$token == "COMMENT") & (pd_flat$lag_newlines == 0L)
+  if (!any(comment_after)) return(pd_flat)
+  comment_before <- lead(comment_after, default = FALSE)
+  pd_flat$spaces[comment_before & (pd_flat$newlines == 0L)] <-
+    pmax(pd_flat$spaces[comment_before], 1L)
+  pd_flat
+}
+
 
 remove_space_after_excl <- function(pd_flat) {
   excl <- (pd_flat$token == "'!'") & (pd_flat$newlines == 0L)

--- a/R/style_guides.R
+++ b/R/style_guides.R
@@ -81,7 +81,7 @@ tidyverse_style <- function(scope = "tokens",
               force_one = start_comments_with_one_space),
 
       remove_space_after_unary_pm_nested,
-      set_space_before_comments,
+      if (strict) set_space_before_comments else add_space_before_comments,
       set_space_between_levels,
       set_space_between_eq_sub_and_comma,
     )

--- a/tests/testthat/spacing/comments-in.R
+++ b/tests/testthat/spacing/comments-in.R
@@ -1,0 +1,4 @@
+a # comment
+b #comment
+c    # comment
+dejk #comment

--- a/tests/testthat/spacing/comments-in_tree
+++ b/tests/testthat/spacing/comments-in_tree
@@ -1,0 +1,13 @@
+ROOT (token: short_text [lag_newlines/spaces] {id})
+ ¦--expr:  [0/1] {4}                               
+ ¦   °--SYMBOL: a [0/0] {1}                        
+ ¦--COMMENT: # com [0/0] {2}                       
+ ¦--expr:  [1/1] {10}                              
+ ¦   °--SYMBOL: b [0/0] {7}                        
+ ¦--COMMENT: #comm [0/0] {8}                       
+ ¦--expr:  [1/4] {16}                              
+ ¦   °--SYMBOL: c [0/0] {13}                       
+ ¦--COMMENT: # com [0/0] {14}                      
+ ¦--expr:  [1/1] {22}                              
+ ¦   °--SYMBOL: dejk [0/0] {19}                    
+ °--COMMENT: #comm [0/0] {20}                      

--- a/tests/testthat/spacing/comments-out.R
+++ b/tests/testthat/spacing/comments-out.R
@@ -1,0 +1,4 @@
+a # comment
+b # comment
+c    # comment
+dejk # comment

--- a/tests/testthat/test-spacing.R
+++ b/tests/testthat/test-spacing.R
@@ -11,3 +11,10 @@ test_that(":, ::, and :::", {
     "spacing", "colon",
     transformer = style_text), NA)
 })
+
+
+test_that("comments and strict = FALSE", {
+  expect_warning(test_collection(
+    "spacing", "comments",
+    transformer = style_text, stric = FALSE), NA)
+})


### PR DESCRIPTION
Allow 
```r
abc   # comment
d     # comment
```
with `strict = FALSE`.

