### PR TITLE
fix R CMD Check

### DIFF
--- a/tests/testthat/strict/non_strict-out.R
+++ b/tests/testthat/strict/non_strict-out.R
@@ -125,7 +125,7 @@ test <- function() {
   )
 
   nested(
-    function_call (with), # a comment and
+    function_call (with),  # a comment and
     many # more
     ,     first_level_args
   )


### PR DESCRIPTION
adapt tests for spacing before comments with strict = FALSE.