### PR TITLE
Allow empty {} without line break.

### DIFF
--- a/R/rules-line_break.R
+++ b/R/rules-line_break.R
@@ -5,26 +5,19 @@ remove_line_break_before_curly_opening <- function(pd) {
   pd
 }
 
-set_line_break_around_curly <- function(pd) {
+style_line_break_around_curly <- function(strict, pd) {
   if (is_curly_expr(pd) && nrow(pd) > 2) {
     closing_before <- pd$token == "'}'"
     opening_before <- (pd$token == "'{'") & (pd$token_after != "COMMENT")
     to_break <- lag(opening_before, default =FALSE) | closing_before
-    pd$lag_newlines[to_break] <- 1L
+    len_to_break <- sum(to_break)
+    pd$lag_newlines[to_break] <- ifelse(rep(strict, len_to_break),
+      1L,
+      pmax(1L, pd$lag_newlines[to_break])
+    )
   }
   pd
 }
-
-add_line_break_around_curly <- function(pd) {
-  if (is_curly_expr(pd) && nrow(pd) > 2) {
-    closing_before <- pd$token == "'}'"
-    opening_before <- (pd$token == "'{'") & (pd$token_after != "COMMENT")
-    to_break <- lag(opening_before, default =FALSE) | closing_before
-    pd$lag_newlines[to_break] <- pmax(1L, pd$lag_newlines[to_break])
-  }
-  pd
-}
-
 
 # if ) follows on }, don't break line
 remove_line_break_before_round_closing_after_curly <- function(pd) {

--- a/R/rules-line_break.R
+++ b/R/rules-line_break.R
@@ -6,18 +6,22 @@ remove_line_break_before_curly_opening <- function(pd) {
 }
 
 set_line_break_around_curly <- function(pd) {
-  closing_before <- pd$token == "'}'"
-  opening_before <- (pd$token == "'{'") & (pd$token_after != "COMMENT")
-  to_break <- lag(opening_before, default =FALSE) | closing_before
-  pd$lag_newlines[to_break] <- 1L
+  if (is_curly_expr(pd) && nrow(pd) > 2) {
+    closing_before <- pd$token == "'}'"
+    opening_before <- (pd$token == "'{'") & (pd$token_after != "COMMENT")
+    to_break <- lag(opening_before, default =FALSE) | closing_before
+    pd$lag_newlines[to_break] <- 1L
+  }
   pd
 }
 
 add_line_break_around_curly <- function(pd) {
-  closing_before <- pd$token == "'}'"
-  opening_before <- (pd$token == "'{'") & (pd$token_after != "COMMENT")
-  to_break <- lag(opening_before, default =FALSE) | closing_before
-  pd$lag_newlines[to_break] <- pmax(1L, pd$lag_newlines[to_break])
+  if (is_curly_expr(pd) && nrow(pd) > 2) {
+    closing_before <- pd$token == "'}'"
+    opening_before <- (pd$token == "'{'") & (pd$token_after != "COMMENT")
+    to_break <- lag(opening_before, default =FALSE) | closing_before
+    pd$lag_newlines[to_break] <- pmax(1L, pd$lag_newlines[to_break])
+  }
   pd
 }
 

--- a/R/rules-line_break.R
+++ b/R/rules-line_break.R
@@ -5,37 +5,22 @@ remove_line_break_before_curly_opening <- function(pd) {
   pd
 }
 
-
-# A { should always be followed by a new line
-set_line_break_afer_curly_opening <- function(pd) {
-  to_break <- (pd$token == "'{'") &
-    (pd$token_after != "COMMENT")
-  pd$lag_newlines[lag(to_break)] <- 1L
-  pd
-}
-
-add_line_break_afer_curly_opening <- function(pd) {
-  to_break <- lag(
-    (pd$token == "'{'") & (pd$token_after != "COMMENT"),
-    default = FALSE
-  )
-  pd$lag_newlines[to_break] <- pmax(1L, pd$lag_newlines[to_break])
-  pd
-}
-
-
-# A } should always go on its own line, unless it’s followed by else or ).
-set_line_break_before_curly_closing <- function(pd) {
-  to_break <- pd$token == "'}'"
+set_line_break_around_curly <- function(pd) {
+  closing_before <- pd$token == "'}'"
+  opening_before <- (pd$token == "'{'") & (pd$token_after != "COMMENT")
+  to_break <- lag(opening_before, default =FALSE) | closing_before
   pd$lag_newlines[to_break] <- 1L
   pd
 }
 
-add_line_break_before_curly_closing <- function(pd) {
-  to_break <- pd$token == "'}'"
+add_line_break_around_curly <- function(pd) {
+  closing_before <- pd$token == "'}'"
+  opening_before <- (pd$token == "'{'") & (pd$token_after != "COMMENT")
+  to_break <- lag(opening_before, default =FALSE) | closing_before
   pd$lag_newlines[to_break] <- pmax(1L, pd$lag_newlines[to_break])
   pd
 }
+
 
 # if ) follows on }, don't break line
 remove_line_break_before_round_closing_after_curly <- function(pd) {

--- a/R/rules-other.R
+++ b/R/rules-other.R
@@ -27,8 +27,8 @@ add_brackets_in_pipe_one <- function(pd, pos) {
 #'   braces. Used for unindention.
 wrap_if_else_multi_line_in_curly <- function(pd, indent_by = 2) {
   if (pd$token[1] == "IF" &&
-      pd_is_multi_line(pd) &&
-      !is_curly_expr(pd$child[[5]])) {
+    pd_is_multi_line(pd) &&
+    !is_curly_expr(pd$child[[5]])) {
     pd$lag_newlines[5] <- 0L
     pd$spaces[4] <- 1L
     pd$spaces[5] <- 0L
@@ -37,9 +37,9 @@ wrap_if_else_multi_line_in_curly <- function(pd, indent_by = 2) {
     pd$child[[5]] <- wrap_expr_in_curly(pd$child[[5]], stretch_out = TRUE)
   }
   if (nrow(pd) > 6 &&
-      (pd$token[6] == "ELSE" && pd_is_multi_line(pd)) &&
-      pd$child[[7]]$token != "IF" &&
-      !is_curly_expr(pd$child[[7]])) {
+    (pd$token[6] == "ELSE" && pd_is_multi_line(pd)) &&
+    pd$child[[7]]$token != "IF" &&
+    !is_curly_expr(pd$child[[7]])) {
     pd$spaces[6] <- 1L
     pd$spaces[7] <- 0L
     pd$indent[7] <- pd$indent[7] - indent_by

--- a/R/style_guides.R
+++ b/R/style_guides.R
@@ -104,10 +104,8 @@ tidyverse_style <- function(scope = "tokens",
       remove_line_break_before_curly_opening,
       if (strict) remove_line_break_before_round_closing_after_curly else identity,
       if (strict) remove_line_break_before_round_closing_fun_dec else identity,
-      if (strict) set_line_break_afer_curly_opening else
-        add_line_break_afer_curly_opening,
-      if (strict) set_line_break_before_curly_closing else
-        add_line_break_before_curly_closing,
+      if (strict) set_line_break_around_curly else
+        add_line_break_around_curly,
       if (strict) partial(
         set_line_break_after_opening_if_call_is_multi_line,
         except_token_after = "COMMENT",

--- a/R/style_guides.R
+++ b/R/style_guides.R
@@ -104,8 +104,7 @@ tidyverse_style <- function(scope = "tokens",
       remove_line_break_before_curly_opening,
       if (strict) remove_line_break_before_round_closing_after_curly else identity,
       if (strict) remove_line_break_before_round_closing_fun_dec else identity,
-      if (strict) set_line_break_around_curly else
-        add_line_break_around_curly,
+      partial(style_line_break_around_curly, strict),
       if (strict) partial(
         set_line_break_after_opening_if_call_is_multi_line,
         except_token_after = "COMMENT",

--- a/tests/testthat/indention_operators/pipe_simple-out.R
+++ b/tests/testthat/indention_operators/pipe_simple-out.R
@@ -4,5 +4,4 @@ a %>%
   d(1 + e(sin(f))) %>%
   g_out()
 
-a <- function(jon_the_pipe) {
-}
+a <- function(jon_the_pipe) {}


### PR DESCRIPTION
* Minor simplification of code based on the insight that curly braces expressions exhibit symmetry, which in turn
* Facilitates checking whether or not a line break should be added before and after an opening / closing curly brace respectively.

Closes #256.