### PR TITLE
Add ability to set cache root within R.cache

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@
 * Enable pre-commit.ci (#843).
 * new R option `styler.cache_root` (defaulting to `"styler"`) that determines 
   the sub-directory under the {R.cache} cache directory that {styler} uses. Non-
-  default caches won't be cleaned up by {styler}.
+  default caches won't be cleaned up by {styler}. We suggest `"styler-perm"` 
+  (also used by {precommit}).
 
 
 # styler 1.6.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * Alignment detection respects stylerignore (#850).
 * Add vignette on distributing style guide (#846).
 * Enable pre-commit.ci (#843).
+* new R option `styler.cache_root` (defaulting to `"styler"`) that determines 
+  the sub-directory under the {R.cache} cache directory that {styler} uses. Non-
+  default caches won't be cleaned up by {styler}.
 
 
 # styler 1.6.2

--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -24,7 +24,7 @@ hash_standardize <- function(text) {
 is_cached <- function(text,
                       transformers,
                       more_specs,
-                      cache_dir = cache_dir()) {
+                      cache_dir = get_cache_dir()) {
   R.cache::generateCache(
     key = cache_make_key(text, transformers, more_specs),
     dirs = cache_dir
@@ -111,7 +111,7 @@ cache_make_key <- function(text, transformers, more_specs) {
 #' @keywords internal
 cache_find_path <- function(cache_name = NULL) {
   cache_name <- cache_get_or_derive_name(cache_name)
-  R.cache::getCachePath(cache_dir(cache_name))
+  R.cache::getCachePath(get_cache_dir(cache_name))
 }
 
 #' Check if a cache is activated
@@ -173,7 +173,7 @@ cache_by_expression <- function(text,
 cache_write <- function(text, transformers, more_specs) {
   R.cache::generateCache(
     key = cache_make_key(text, transformers, more_specs),
-    dirs = cache_dir()
+    dirs = get_cache_dir()
   ) %>%
     file.create()
 }
@@ -194,7 +194,7 @@ cache_get_or_derive_name <- function(cache_name) {
   cache_name
 }
 
-cache_dir <- function(cache_name = cache_get_name()) {
+get_cache_dir <- function(cache_name = cache_get_name()) {
   c(getOption("styler.cache_root", "styler"), cache_name)
 }
 

--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -24,7 +24,7 @@ hash_standardize <- function(text) {
 is_cached <- function(text,
                       transformers,
                       more_specs,
-                      cache_dir = cache_dir_default()) {
+                      cache_dir = cache_dir()) {
   R.cache::generateCache(
     key = cache_make_key(text, transformers, more_specs),
     dirs = cache_dir
@@ -111,7 +111,7 @@ cache_make_key <- function(text, transformers, more_specs) {
 #' @keywords internal
 cache_find_path <- function(cache_name = NULL) {
   cache_name <- cache_get_or_derive_name(cache_name)
-  R.cache::getCachePath(c("styler", cache_name))
+  R.cache::getCachePath(cache_dir(cache_name))
 }
 
 #' Check if a cache is activated
@@ -173,7 +173,7 @@ cache_by_expression <- function(text,
 cache_write <- function(text, transformers, more_specs) {
   R.cache::generateCache(
     key = cache_make_key(text, transformers, more_specs),
-    dirs = cache_dir_default()
+    dirs = cache_dir()
   ) %>%
     file.create()
 }
@@ -194,8 +194,8 @@ cache_get_or_derive_name <- function(cache_name) {
   cache_name
 }
 
-cache_dir_default <- function() {
-  c("styler", cache_get_name())
+cache_dir <- function(cache_name = cache_get_name()) {
+  c(getOption("styler.cache_root", "styler"), cache_name)
 }
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,6 +3,7 @@
   op <- options()
   op.styler <- list(
     styler.addins_style_transformer = "styler::tidyverse_style()",
+    styler.cache_root = "styler",
     styler.cache_name = styler_version,
     styler.colored_print.vertical = TRUE,
     styler.ignore_start = "# styler: off",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,7 +3,7 @@
   op <- options()
   op.styler <- list(
     styler.addins_style_transformer = "styler::tidyverse_style()",
-    styler.cache_root = "styler",
+    styler.cache_root = NULL,
     styler.cache_name = styler_version,
     styler.colored_print.vertical = TRUE,
     styler.ignore_start = "# styler: off",
@@ -13,9 +13,32 @@
   )
   toset <- !(names(op.styler) %in% names(op))
   if (any(toset)) options(op.styler[toset])
+  ask_to_switch_to_non_default_cache_root()
   remove_cache_old_versions()
   remove_old_cache_files()
   invisible()
+}
+
+
+ask_to_switch_to_non_default_cache_root <- function(ask = interactive()) {
+  if (ask && runif(1) > 0.9 && is.null(getOption("styler.cache_root"))) {
+    cli::cli_inform(paste0(
+      "The R option `styler.cache_root` is not set, which means the cache ",
+      "will get cleaned up after 6 days (and repeated styling will be slower).",
+      " To keep cache files longer, set ",
+      "the option to location within the {{R.cache}} cache where you want to ",
+      "store the cache, e.g. `\"styler-perm\"`.\n\n",
+      "options(styler.cache_root = \"styler-perm\")\n\n",
+      "in your .Rprofile. Note that the cache literally ",
+      "takes zero space on your disk, only the inode, and you can always ",
+      "manually clean up with `styler::cache_clear()`, and if you update the ",
+      "{{styler}} package, the cache is removed in any case. To ignore this ",
+      "message in the future, set the default explictly to \"styler\" with\n\n",
+      "options(styler.cache_root = \"styler\")\n\nin your `.Rprofile`. This ",
+      "message will only be displayed once in a while.\n"
+    ))
+  }
+  options(styler.cache_root = "styler")
 }
 
 remove_old_cache_files <- function() {

--- a/man/cache_by_expression.Rd
+++ b/man/cache_by_expression.Rd
@@ -13,7 +13,7 @@ cache_by_expression(text, transformers, more_specs)
 know if text is already correct if we know which transformer function it
 should be styled with.}
 
-\item{more_specs}{A named vector coercible to it character that determine the
+\item{more_specs}{A named vector coercible to character that determines the
 styling but are style guide independent, such as \code{include_roxygen_examples}
 or \code{base_indention}.}
 }

--- a/man/cache_make_key.Rd
+++ b/man/cache_make_key.Rd
@@ -14,7 +14,7 @@ approach used by styler does not cache input, but styled code.}
 know if text is already correct if we know which transformer function it
 should be styled with.}
 
-\item{more_specs}{A named vector coercible to it character that determine the
+\item{more_specs}{A named vector coercible to character that determines the
 styling but are style guide independent, such as \code{include_roxygen_examples}
 or \code{base_indention}.}
 }

--- a/man/cache_write.Rd
+++ b/man/cache_write.Rd
@@ -14,7 +14,7 @@ approach used by styler does not cache input, but styled code.}
 know if text is already correct if we know which transformer function it
 should be styled with.}
 
-\item{more_specs}{A named vector coercible to it character that determine the
+\item{more_specs}{A named vector coercible to character that determines the
 styling but are style guide independent, such as \code{include_roxygen_examples}
 or \code{base_indention}.}
 }

--- a/man/is_cached.Rd
+++ b/man/is_cached.Rd
@@ -4,7 +4,7 @@
 \alias{is_cached}
 \title{Check if text is cached}
 \usage{
-is_cached(text, transformers, more_specs, cache_dir = cache_dir_default())
+is_cached(text, transformers, more_specs, cache_dir = cache_dir())
 }
 \arguments{
 \item{text, transformers, more_specs}{Passed to \code{\link[=cache_make_key]{cache_make_key()}} to generate

--- a/man/is_cached.Rd
+++ b/man/is_cached.Rd
@@ -4,7 +4,7 @@
 \alias{is_cached}
 \title{Check if text is cached}
 \usage{
-is_cached(text, transformers, more_specs, cache_dir = cache_dir())
+is_cached(text, transformers, more_specs, cache_dir = get_cache_dir())
 }
 \arguments{
 \item{text, transformers, more_specs}{Passed to \code{\link[=cache_make_key]{cache_make_key()}} to generate


### PR DESCRIPTION
Closes #852. Needs doc and message to set root if interactive in `.onLoad()`: If `FALSE`, silent, if `TRUE` silent, if not set, info.