### PR TITLE
Make no trailing line a pre-processing step like trimming whitespaces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
   (also used by {precommit}).
 * rename default branch to main (#859).
 * Fix argument name `filetype` in Example for `style_dir()` (#855).
+* ensure a trailing blank line also if the input is cached (#867).
 * Bump minimal R requirement to 3.4 in line with the [tidyverse](https://www.tidyverse.org/blog/2019/04/r-version-support/), which 
   allowed to remove the dependency at {backports} and some exception handling.
 * Remove dependency on {xfun} (#866).

--- a/R/transform-files.R
+++ b/R/transform-files.R
@@ -88,7 +88,7 @@ make_transformer <- function(transformers,
   assert_transformers(transformers)
 
   function(text) {
-    text <- trimws(text, which = "right")
+    text <- ensure_last_n_empty(trimws(text, which = "right"), n = 0L)
     should_use_cache <- cache_is_activated()
 
     if (should_use_cache) {

--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -1,13 +1,13 @@
 #' Standardize text for hashing
 #'
 #' Make sure text after styling results in the same hash as text before styling
-#' if it is indeed identical.
+#' if it is indeed identical. This function expects trailing blank lines in
+#' `text` were removed prior to passing it to this function.
 #' @param text A character vector.
 #' @keywords internal
 hash_standardize <- function(text) {
   text %>%
     convert_newlines_to_linebreaks() %>%
-    ensure_last_n_empty() %>%
     enc2utf8() %>%
     paste0(collapse = "\n") %>%
     list()

--- a/man/hash_standardize.Rd
+++ b/man/hash_standardize.Rd
@@ -11,6 +11,7 @@ hash_standardize(text)
 }
 \description{
 Make sure text after styling results in the same hash as text before styling
-if it is indeed identical.
+if it is indeed identical. This function expects trailing blank lines in
+\code{text} were removed prior to passing it to this function.
 }
 \keyword{internal}


### PR DESCRIPTION
Not sure we can omit setting trailing whitespace now in `hash_standardize` -> `cache_make_key()` to speed things up a little bit. Closes #865.