### PR TITLE
Reject styling wrongly parsed coder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,8 @@
 * Add vignette on distributing style guide (#846, #861).
 * ensure a trailing blank line also if the input is cached (#867).
 * Fix argument name `filetype` in Example for `style_dir()` (#855).
+* An error is now thrown on styling if input unicode characters can't be 
+  correctly parsed for Windows and R < 4.2 (#883).
 
 **Infrastructure**
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -101,11 +101,11 @@ get_parse_data <- function(text, include_text = TRUE, ...) {
   if (getRversion() < "4.2") {
     is_unicode_parsing_error <- grepl("^\"<U\\+[0-9]+>\"$", pd$text)
     if (any(is_unicode_parsing_error)) {
-      rlang::abort(
+      rlang::abort(paste0(
         "Can't parse input due to unicode restriction in base R. Please ",
         "upgrade R to >= 4.2 to style this input. ",
         "Context: https://github.com/r-lib/styler/issues/847"
-      )
+      ))
     }
   }
   pd <- pd %>%

--- a/R/parse.R
+++ b/R/parse.R
@@ -97,7 +97,18 @@ get_parse_data <- function(text, include_text = TRUE, ...) {
   pd <- as_tibble(
     utils::getParseData(parsed, includeText = include_text),
     .name_repair = "minimal"
-  ) %>%
+  )
+  if (getRversion() < "4.2") {
+    is_unicode_parsing_error <- grepl("^\"<U\\+[0-9]+>\"$", pd$text)
+    if (any(is_unicode_parsing_error)) {
+      rlang::abort(
+        "Can't parse input due to unicode restriction in base R. Please ",
+        "upgrade R to style this input. ",
+        "Context: https://github.com/r-lib/styler/issues/847"
+      )
+    }
+  }
+  pd <- pd %>%
     add_id_and_short()
 
   parser_version_set(parser_version_find(pd))

--- a/R/parse.R
+++ b/R/parse.R
@@ -103,7 +103,7 @@ get_parse_data <- function(text, include_text = TRUE, ...) {
     if (any(is_unicode_parsing_error)) {
       rlang::abort(
         "Can't parse input due to unicode restriction in base R. Please ",
-        "upgrade R to style this input. ",
+        "upgrade R to >= 4.2 to style this input. ",
         "Context: https://github.com/r-lib/styler/issues/847"
       )
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,6 +70,9 @@ even_index <- function(x) {
   seq(2L, length(x), by = 2)
 }
 
+is_windows <- function() {
+  identical(.Platform$OS.type, "windows")
+}
 
 #' Invoke a system command
 #'
@@ -79,7 +82,7 @@ even_index <- function(x) {
 #' @param ... Arguments passed to [shell()] or [system()].
 #' @keywords internal
 calls_sys <- function(sys_call, ...) {
-  if (Sys.info()[1] == "Windows") {
+  if (is_windows()) {
     error <- shell(sys_call, ...)
   } else {
     error <- system(sys_call, ...)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -243,6 +243,7 @@ ubuntu
 ui
 uncached
 unexplainable
+unicode
 unindent
 unindention
 unlink

--- a/tests/testthat/test-parsing.R
+++ b/tests/testthat/test-parsing.R
@@ -63,3 +63,11 @@ test_that("mixed CRLF / LF EOLs fail", {
     "unexpected input"
   )
 })
+
+test_that("unicode can't be propprely handled on Windows for R < 4.2", {
+  msg <- ifelse(getRversion() < 4.2 && is_windows(),
+    "Can't parse input due to unicode restriction in base R\\.",
+    NA
+  )
+  expect_error(style_text('suit <- "♠"'), msg)
+})


### PR DESCRIPTION
Closes #847. Turns out we can't fix the problem because we can't construct a string like `"\U2660"` from "\U" and 2660: Error: '\U' used without hex digits in character string starting ""\U"". So windows users have to wait for R 4.2. @IndrajeetPatil I added a test to make sure it errors under certain circumstances. 