### PR TITLE
Add pluralization + clickable hyperlink support

### DIFF
--- a/R/transform-files.R
+++ b/R/transform-files.R
@@ -22,7 +22,7 @@ transform_files <- function(files,
   max_char <- min(max(nchar(files), 0L), getOption("width"))
   len_files <- length(files)
   if (len_files > 0L && !getOption("styler.quiet", FALSE)) {
-    cat("Styling ", len_files, " files:\n")
+    cli::cli_inform("Styling {len_files} file{?s}:")
   }
 
   changed <- map_lgl(files, transform_file,
@@ -59,7 +59,8 @@ transform_file <- function(path,
     max_char_after_message_path - char_after_path
   if (!getOption("styler.quiet", FALSE)) {
     cat(
-      message_before, path,
+      message_before,
+      cli::format_inline("{.file {path}}"), # path
       rep_char(" ", max(0L, n_spaces_before_message_after)),
       append = FALSE
     )

--- a/tests/testthat/_snaps/public_api-1.md
+++ b/tests/testthat/_snaps/public_api-1.md
@@ -3,9 +3,10 @@
     Code
       cat(catch_style_file_output(file.path("public-api", "xyzdir-dirty",
         "dirty-sample-with-scope-tokens.R")), sep = "\n")
+    Message
+      Styling 1 file:
     Output
-      Styling  1  files:
-       dirty-sample-with-scope-tokens.R i 
+       'dirty-sample-with-scope-tokens.R' i 
       ----------------------------------------
       Status	Count	Legend 
       v 	0	File unchanged.
@@ -19,9 +20,10 @@
     Code
       cat(catch_style_file_output(file.path("public-api", "xyzdir-dirty",
         "clean-sample-with-scope-tokens.R")), sep = "\n")
+    Message
+      Styling 1 file:
     Output
-      Styling  1  files:
-       clean-sample-with-scope-tokens.R v 
+       'clean-sample-with-scope-tokens.R' v 
       ----------------------------------------
       Status	Count	Legend 
       v 	1	File unchanged.
@@ -34,9 +36,10 @@
     Code
       cat(catch_style_file_output(file.path("public-api", "xyzdir-dirty",
         "dirty-sample-with-scope-spaces.R")), sep = "\n")
+    Message
+      Styling 1 file:
     Output
-      Styling  1  files:
-       dirty-sample-with-scope-spaces.R i 
+       'dirty-sample-with-scope-spaces.R' i 
       ----------------------------------------
       Status	Count	Legend 
       v 	0	File unchanged.


### PR DESCRIPTION
Addresses part of #1116.

For speed / usefulness, maybe should only hyperlink the files that changed?
Support pluralization + clickable hyperlink

Demo (since #1187 is merged):

![image](https://github.com/r-lib/styler/assets/52606734/2479b85d-14c3-428a-820c-63cc5e4c6de0)

styler 1.10.2 
![image](https://github.com/r-lib/styler/assets/52606734/951df53a-83a2-4a8a-bd13-c34a3d7f1caa)
