### PR TITLE
Update personal website link to new domain

### DIFF
--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -52,7 +52,7 @@ authors:
   Lorenz Walthert:
     href: https://lorenzwalthert.com
   Indrajeet Patil:
-    href: https://indrajeetpatil.github.io/
+    href: https://indrajeetpatil.github.io
 
 development:
   mode: auto

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -52,7 +52,7 @@ authors:
   Lorenz Walthert:
     href: https://lorenzwalthert.com
   Indrajeet Patil:
-    href: https://sites.google.com/site/indrajeetspatilmorality/
+    href: https://indrajeetpatil.github.io/
 
 development:
   mode: auto

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -75,6 +75,7 @@ https
 icloud
 ifelse
 Indrajeet
+indrajeetpatil
 indrajeetspatilmorality
 initializer
 inode


### PR DESCRIPTION
The author's personal website has moved from the old Google Sites domain to a new domain.

This updates the author link in `_pkgdown.yaml` accordingly.